### PR TITLE
Prevent premature bean initialization

### DIFF
--- a/src/main/java/org/zalando/baigan/context/ConfigurationContextProviderBeanPostprocessor.java
+++ b/src/main/java/org/zalando/baigan/context/ConfigurationContextProviderBeanPostprocessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package org.zalando.baigan.context;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Component;
@@ -33,15 +34,19 @@ import org.zalando.baigan.provider.ContextProvider;
 public class ConfigurationContextProviderBeanPostprocessor
         implements BeanPostProcessor {
 
+    private final ObjectFactory<ContextProviderRegistry> registry;
+
     @Autowired
-    private ContextProviderRegistry registry;
+    public ConfigurationContextProviderBeanPostprocessor(final ObjectFactory<ContextProviderRegistry> registry) {
+        this.registry = registry;
+    }
 
     @Override
     public Object postProcessAfterInitialization(final Object bean,
             final String beanName) throws BeansException {
         if (ContextProvider.class.isInstance(bean)) {
             final ContextProvider contextProvider = (ContextProvider) bean;
-            registry.register(contextProvider);
+            registry.getObject().register(contextProvider);
         }
         return bean;
     }

--- a/src/main/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactory.java
+++ b/src/main/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactory.java
@@ -1,15 +1,11 @@
 package org.zalando.baigan.proxy;
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.AbstractFactoryBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.zalando.baigan.annotation.BaiganConfig;
-import org.zalando.baigan.proxy.handler.ConfigurationMethodInvocationHandler;
-import org.zalando.baigan.service.ConfigurationRepository;
-
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.Reflection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.zalando.baigan.annotation.BaiganConfig;
+import org.zalando.baigan.proxy.handler.ConfigurationMethodInvocationHandler;
 
 /**
  * Factory class that creates the proxy implementations for the interfaces
@@ -18,23 +14,20 @@ import com.google.common.reflect.Reflection;
  * @author mchand
  *
  */
-public class ConfigurationServiceBeanFactory extends AbstractFactoryBean<Object>
-        implements ApplicationContextAware {
+public class ConfigurationServiceBeanFactory extends AbstractFactoryBean<Object> {
 
     private Class<?> candidateInterface;
 
-    private ConfigurationRepository configurationRepository;
+    private final ConfigurationMethodInvocationHandler methodInvocationHandler;
 
-    private ApplicationContext applicationContext;
+    @Autowired
+    public ConfigurationServiceBeanFactory(final ConfigurationMethodInvocationHandler methodInvocationHandler) {
+        this.methodInvocationHandler = methodInvocationHandler;
+    }
 
     public void setCandidateInterface(final Class<?> candidateInterface) {
         this.candidateInterface = candidateInterface;
     }
-
-    /**
-     * Returns a proxy that implements the given interface.
-     *
-     */
 
     protected Object createInstance() {
 
@@ -44,29 +37,12 @@ public class ConfigurationServiceBeanFactory extends AbstractFactoryBean<Object>
                 "This BeanFactory could only create Beans for classes annotated with "
                         + BaiganConfig.class.getName());
 
-        final ConfigurationMethodInvocationHandler invocationHandler = applicationContext
-                .getBean(ConfigurationMethodInvocationHandler.class);
-        return Reflection.newProxy(candidateInterface, invocationHandler);
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext)
-            throws BeansException {
-        this.applicationContext = applicationContext;
-
+        return Reflection.newProxy(candidateInterface, methodInvocationHandler);
     }
 
     @Override
     public Class<?> getObjectType() {
         return this.candidateInterface;
-    }
-
-    public void setConfigurationRepository(final ConfigurationRepository configurationRepository) {
-        this.configurationRepository = configurationRepository;
-    }
-
-    public ConfigurationRepository getConfigurationRespository() {
-        return this.configurationRepository;
     }
 
 }

--- a/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
+++ b/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
@@ -23,6 +23,7 @@ enum State {
 }
 
 interface Express {
+
     State stateDefault();
 
     int maxDeliveryDays();
@@ -48,7 +49,7 @@ public class MethodInvocationHandlerTest {
                 org.mockito.Answers.RETURNS_SMART_NULLS.toString());
 
         ContextAwareConfigurationMethodInvocationHandler handler = new ContextAwareConfigurationMethodInvocationHandler(
-                repo, new ConditionsProcessor(), retriever);
+                () -> repo, ConditionsProcessor::new, () -> retriever);
 
         Method method = Express.class.getMethod("stateDefault");
         Object object = handler.invoke("", method, new String[]{});
@@ -69,7 +70,7 @@ public class MethodInvocationHandlerTest {
                 org.mockito.Answers.RETURNS_SMART_NULLS.toString());
 
         ContextAwareConfigurationMethodInvocationHandler handler = new ContextAwareConfigurationMethodInvocationHandler(
-                repo, new ConditionsProcessor(), retriever);
+                () -> repo, ConditionsProcessor::new, () -> retriever);
 
         Method method = Express.class.getMethod("maxDeliveryDays");
         Object object = handler.invoke("", method, new String[]{});

--- a/src/test/java/org/zalando/baigan/context/SpringTestContext.java
+++ b/src/test/java/org/zalando/baigan/context/SpringTestContext.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * @author mchand
  */
 @Configuration
-class SpringTestContext {
+public class SpringTestContext {
 
     @Bean
     public ConditionsProcessor ConditionsProcessor() {

--- a/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderBeanPostProcessor.java
+++ b/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderBeanPostProcessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,37 +16,29 @@
 
 package org.zalando.baigan.context;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.zalando.baigan.context.ConfigurationContextProviderBeanPostprocessor;
-import org.zalando.baigan.context.ContextProviderRegistry;
 import org.zalando.baigan.provider.ContextProvider;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 /**
- *
  * @author mchand
- *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class TestConfigurationContextProviderBeanPostProcessor {
 
-    @Mock
-    private ContextProviderRegistry registry;
+    private final ContextProvider provider = mock(ContextProvider.class);
 
-    @InjectMocks
-    private ConfigurationContextProviderBeanPostprocessor processor;
+    private final ContextProviderRegistry registry = mock(ContextProviderRegistry.class);
 
-    @Mock
-    private ContextProvider provider;
+    private ConfigurationContextProviderBeanPostprocessor processor = new ConfigurationContextProviderBeanPostprocessor(() -> registry);
 
     @Test
     public void testMessenger() {

--- a/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
+++ b/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
@@ -1,0 +1,87 @@
+package org.zalando.baigan.proxy;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zalando.baigan.BaiganSpringContext;
+import org.zalando.baigan.annotation.BaiganConfig;
+import org.zalando.baigan.annotation.ConfigurationServiceScan;
+import org.zalando.baigan.context.SpringTestContext;
+import org.zalando.baigan.service.ConfigurationRepository;
+import org.zalando.baigan.service.github.GitConfig;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ConfigurationServiceBeanFactoryIT.TestContext.class})
+public class ConfigurationServiceBeanFactoryIT {
+
+    @Configuration
+    @ComponentScan(
+            basePackageClasses = {BaiganSpringContext.class},
+            excludeFilters = @ComponentScan.Filter(
+                    classes = SpringTestContext.class,
+                    type = FilterType.ASSIGNABLE_TYPE))
+    @ConfigurationServiceScan(basePackages = "org.zalando.baigan.proxy")
+    static class TestContext {
+
+        @Bean
+        ConfigurationRepository configurationRepository(final GitConfig configuration) {
+            return mock(ConfigurationRepository.class);
+        }
+
+        @Bean(name = "gitConfiguration")
+        GitConfig gitConfiguration() {
+            final GitConfig config = mock(GitConfig.class);
+            when(config.getGitHost()).thenReturn("raw.com");
+            return config;
+        }
+
+        @Bean
+        static TestPostProcessor testPostProcessor() {
+            return new TestPostProcessor();
+        }
+
+    }
+
+    static class TestPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessBeforeInitialization(final Object bean, final String beanName) throws BeansException {
+            return bean;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
+            if ("gitConfiguration".equals(beanName)) {
+                when(((GitConfig) bean).getGitHost()).thenReturn("post-processed.com");
+            }
+            return bean;
+        }
+    }
+
+    @BaiganConfig
+    public interface TestFeature {
+
+        Boolean enabled();
+    }
+
+    @Autowired
+    private GitConfig gitConfig;
+
+    @Test
+    public void allowsPostProcessingOfBeans() throws Exception {
+        assertThat(gitConfig.getGitHost(), is("post-processed.com"));
+    }
+}


### PR DESCRIPTION
This pull request is a proposal to delay some of the bean initialization done by the custom `PostProcessor` of **baigan**. I propose to delay to prevent any premature bean initialization, which leads to problems in later stages of the context refresh, e.g. other post processors may not be eligible anymore.