### PR TITLE
Allow early resolution by BeanFactoryPostProcessors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,21 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactory.java
+++ b/src/main/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactory.java
@@ -1,29 +1,21 @@
 package org.zalando.baigan.proxy;
 
-import com.google.common.base.Preconditions;
 import com.google.common.reflect.Reflection;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.zalando.baigan.annotation.BaiganConfig;
 import org.zalando.baigan.proxy.handler.ConfigurationMethodInvocationHandler;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Factory class that creates the proxy implementations for the interfaces
  * marked with {@link BaiganConfig}.
  *
  * @author mchand
- *
  */
 public class ConfigurationServiceBeanFactory extends AbstractFactoryBean<Object> {
 
     private Class<?> candidateInterface;
-
-    private final ConfigurationMethodInvocationHandler methodInvocationHandler;
-
-    @Autowired
-    public ConfigurationServiceBeanFactory(final ConfigurationMethodInvocationHandler methodInvocationHandler) {
-        this.methodInvocationHandler = methodInvocationHandler;
-    }
 
     public void setCandidateInterface(final Class<?> candidateInterface) {
         this.candidateInterface = candidateInterface;
@@ -31,13 +23,13 @@ public class ConfigurationServiceBeanFactory extends AbstractFactoryBean<Object>
 
     protected Object createInstance() {
 
-        final BaiganConfig beanConfig = candidateInterface
-                .getAnnotation(BaiganConfig.class);
-        Preconditions.checkNotNull(beanConfig,
+        final BaiganConfig beanConfig = candidateInterface.getAnnotation(BaiganConfig.class);
+        checkNotNull(beanConfig,
                 "This BeanFactory could only create Beans for classes annotated with "
                         + BaiganConfig.class.getName());
 
-        return Reflection.newProxy(candidateInterface, methodInvocationHandler);
+        final ConfigurationMethodInvocationHandler handler = getBeanFactory().getBean(ConfigurationMethodInvocationHandler.class);
+        return Reflection.newProxy(candidateInterface, handler);
     }
 
     @Override

--- a/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
+++ b/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
@@ -2,9 +2,11 @@ package org.zalando.baigan.context;
 
 import com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.springframework.beans.factory.BeanFactory;
 import org.zalando.baigan.model.Configuration;
 import org.zalando.baigan.proxy.handler.ContextAwareConfigurationMethodInvocationHandler;
 import org.zalando.baigan.service.ConditionsProcessor;
@@ -44,12 +46,7 @@ public class MethodInvocationHandlerTest {
                 ImmutableSet.of(), "SHIPPING");
         when(repo.get(anyString())).thenReturn(Optional.of(configuration));
 
-        final ContextProviderRetriever retriever = mock(
-                ContextProviderRetriever.class,
-                org.mockito.Answers.RETURNS_SMART_NULLS.toString());
-
-        ContextAwareConfigurationMethodInvocationHandler handler = new ContextAwareConfigurationMethodInvocationHandler(
-                () -> repo, ConditionsProcessor::new, () -> retriever);
+        final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
 
         Method method = Express.class.getMethod("stateDefault");
         Object object = handler.invoke("", method, new String[]{});
@@ -65,16 +62,27 @@ public class MethodInvocationHandlerTest {
                 "This is a test configuration object.", ImmutableSet.of(), "3");
         when(repo.get(anyString())).thenReturn(Optional.of(configuration));
 
-        final ContextProviderRetriever retriever = mock(
-                ContextProviderRetriever.class,
-                org.mockito.Answers.RETURNS_SMART_NULLS.toString());
-
-        ContextAwareConfigurationMethodInvocationHandler handler = new ContextAwareConfigurationMethodInvocationHandler(
-                () -> repo, ConditionsProcessor::new, () -> retriever);
+        final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
 
         Method method = Express.class.getMethod("maxDeliveryDays");
         Object object = handler.invoke("", method, new String[]{});
         assertThat(object, Matchers.equalTo(3));
+    }
+
+    private ContextAwareConfigurationMethodInvocationHandler createHandler(final ConfigurationRepository repository) {
+        final ContextProviderRetriever retriever = mock(
+                ContextProviderRetriever.class,
+                org.mockito.Answers.RETURNS_SMART_NULLS.toString());
+
+        final BeanFactory beanFactory = mock(BeanFactory.class);
+        when(beanFactory.getBean(ContextProviderRetriever.class)).thenReturn(retriever);
+        when(beanFactory.getBean(ConfigurationRepository.class)).thenReturn(repository);
+        when(beanFactory.getBean(ConditionsProcessor.class)).thenReturn(new ConditionsProcessor());
+
+        final ContextAwareConfigurationMethodInvocationHandler handler =
+                new ContextAwareConfigurationMethodInvocationHandler();
+        handler.setBeanFactory(beanFactory);
+        return handler;
     }
 
 }

--- a/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
+++ b/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
@@ -4,7 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +20,7 @@ import org.zalando.baigan.context.SpringTestContext;
 import org.zalando.baigan.service.ConfigurationRepository;
 import org.zalando.baigan.service.github.GitConfig;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -53,6 +56,11 @@ public class ConfigurationServiceBeanFactoryIT {
             return new TestPostProcessor();
         }
 
+        @Bean
+        static TestBeanFactoryPostProcessor testBeanFactoryPostProcessor() {
+            return new TestBeanFactoryPostProcessor();
+        }
+
     }
 
     static class TestPostProcessor implements BeanPostProcessor {
@@ -71,6 +79,22 @@ public class ConfigurationServiceBeanFactoryIT {
         }
     }
 
+    static class MyDependency {
+
+    }
+
+    static class TestBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+        @Override
+        public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory) throws BeansException {
+            // force instantiation of factory beans
+            beanFactory.getBeanNamesForType(MyDependency.class);
+
+            // proof that post processor actually runs
+            beanFactory.registerSingleton("myBean", new MyDependency());
+        }
+    }
+
     @BaiganConfig
     public interface TestFeature {
 
@@ -80,8 +104,16 @@ public class ConfigurationServiceBeanFactoryIT {
     @Autowired
     private GitConfig gitConfig;
 
+    @Autowired
+    private MyDependency myDependency;
+
     @Test
     public void allowsPostProcessingOfBeans() throws Exception {
         assertThat(gitConfig.getGitHost(), is("post-processed.com"));
+    }
+
+    @Test
+    public void allowsPostProcessingOfFactoryBeans() throws Exception {
+        assertThat(myDependency, is(notNullValue()));
     }
 }


### PR DESCRIPTION
In #25 bean resolution has been changed to prevent any premature initialization of beans due to the proxy beans created by baigan. Still usage of `BeanFactoryPostProcessor`s (e.g. [MockitoPostProcessor](http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.html)) may lead to issues as such a processor is allowed to load the `ConfigurationServiceBeanFactory` very early.

* `ConfigurationServiceBeanFactory` uses `BeanFactory` instead of injection to allow early calls to *createInstance* by `BeanFactoryPostProcessor`s
* Consequential `ContextAwareConfigurationMethodInvocationHandler` defers dependency injection to allow early creation as a dependency of `ConfigurationServiceBeanFactory` to break any potential cyclic dependencies