### PR TITLE
Release 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Baigan configuration
 
+[![Maven Central](https://img.shields.io/maven-central/v/org.zalando/baigan-config.svg)](https://maven-badges.herokuapp.com/maven-central/org.zalando/baigan-config)
+
 Baigan configuration is an easy to use configuration framework for [Spring](https://spring.io/) based applications.
 
 What makes Baigan a rockstar configuration framework ?

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.zalando</groupId>
     <artifactId>baigan-config</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>0.12.1</version>
     <packaging>jar</packaging>
 
     <name>baigan-config</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.zalando</groupId>
     <artifactId>baigan-config</artifactId>
-    <version>0.12.1</version>
+    <version>0.12.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>baigan-config</name>


### PR DESCRIPTION
Release of version `0.12.1` with the following changes (including `0.12.0`):

* GH-20 deployment artifacts include java-doc and sources
* GH-23 no dependency to `cassandra` anymore
* GH-25 and GH-27 no more premature bean initialization (fixes usage of bean post processors)