### PR TITLE
Allow feature resolution on base interface

### DIFF
--- a/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
+++ b/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
 
 /**
@@ -61,8 +62,7 @@ public class ContextAwareConfigurationMethodInvocationHandler
     protected Object handleInvocation(Object proxy, Method method,
             Object[] args) throws Throwable {
         final String methodName = method.getName();
-
-        final String nameSpace = method.getDeclaringClass().getSimpleName();
+        final String nameSpace = getNamespace(proxy);
 
         final String key = ProxyUtils.dottify(nameSpace) + "."
                 + ProxyUtils.dottify(methodName);
@@ -104,6 +104,12 @@ public class ContextAwareConfigurationMethodInvocationHandler
                     exception);
         }
         return null;
+    }
+
+    private String getNamespace(final Object proxy) {
+        final Class<?>[] interfaces = proxy.getClass().getInterfaces();
+        checkState(interfaces.length == 1, "Expected exactly one interface on proxy object.");
+        return interfaces[0].getSimpleName();
     }
 
     private Object getConfig(final String key) {


### PR DESCRIPTION
Changes configuration key resolution to allows rely on the concrete interface used to generate a `@BaiganConfig` proxy object.


```
interface Base {
boolean isActive();
}

@BaiganConfig
interface MyFeature extends Base {
String version();
}
```

Before this pull request an instance of `MyFeature` would resolve to `base.is.active` on calling `MyFeature#isActive()`, we am proposing to resolve to `my.feature.is.active` to allow multiple bagain configuration definitions to inherit a common interface while being independent configuration wise.

What do you think?