### PR TITLE
Safe Handling of Illegal Enum Values

### DIFF
--- a/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
+++ b/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
@@ -90,7 +90,8 @@ public class ContextAwareConfigurationMethodInvocationHandler
                         return t;
                     }
                 }
-                return result;
+                LOG.warn("Unable to map [{}] to enum type [{}].", result, declaredReturnType.getName());
+                return null;
             } else {
                 constructor = declaredReturnType
                         .getDeclaredConstructor(result.getClass());

--- a/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
+++ b/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.reflect.Reflection.newProxy;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -57,6 +58,19 @@ public class MethodInvocationHandlerTest {
 
         Object object = invokeHandler(handler, Express.class, "stateDefault");
         assertThat(object, Matchers.equalTo(State.SHIPPING));
+    }
+
+    @Test
+    public void testIllegalEnumValue() throws Throwable {
+
+        final ConfigurationRepository repo = mock(ConfigurationRepository.class);
+        final Configuration<String> configuration = new Configuration<>("express.state.default", DESCRIPTION, of(), "42");
+        when(repo.get(anyString())).thenReturn(Optional.of(configuration));
+
+        final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
+
+        Object object = invokeHandler(handler, Express.class, "stateDefault");
+        assertThat(object, is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
If configuration value cannot be mapped to enum value range, return `null`.  This stops `ClassCastException` as happening currently.