### PR TITLE
Replace guava-retrying with failsafe.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,9 +167,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.rholder</groupId>
-            <artifactId>guava-retrying</artifactId>
-            <version>2.0.0</version>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>1.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes #36.

I propose to replace `guava-retrying` with `failsafe` as the latter has no dependency and seems more mature.